### PR TITLE
feat: add projects from previous years

### DIFF
--- a/app/components/nav-dropdown.tsx
+++ b/app/components/nav-dropdown.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+
+export default function PastYearsDropdown() {
+  const menuItems = [
+    // { label: "2024", href: "/projects" },
+    { label: "2023", href: "/projects/2023" },
+    { label: "2021", href: "/projects/2021" },
+    { label: "2020", href: "/projects/2020" },
+  ];
+
+  return (
+    <div className="relative">
+      <ChevronDown className="size-6 p-1 transition-transform text-zinc-400 group-hover:text-zinc-300 duration-200 group-hover:rotate-180" />
+
+      <div className="absolute hidden group-hover:block right-0">
+        <div className="bg-zinc-900 shadow-lg w-28 text-sm py-1 mt-2 border border-zinc-800 rounded-lg">
+            {/* <span className="text-[0.7rem] leading-3 px-4 text-zinc-600">Previous years</span> */}
+          {menuItems.map((item) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              className="text-zinc-400 block py-2 px-4 hover:text-zinc-300"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/app/components/nav-dropdown.tsx
+++ b/app/components/nav-dropdown.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function PastYearsDropdown() {
   const menuItems = [
-    // { label: "2024", href: "/projects" },
+    { label: "2024", href: "/projects" },
     { label: "2023", href: "/projects/2023" },
     { label: "2021", href: "/projects/2021" },
     { label: "2020", href: "/projects/2020" },

--- a/app/components/nav-dropdown.tsx
+++ b/app/components/nav-dropdown.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ChevronDown } from "lucide-react";
 import Link from "next/link";
 

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -29,10 +29,28 @@ export const Navigation: React.FC = () => {
 				<div className="container flex flex-row-reverse items-center justify-between p-6 mx-auto">
 					<div className="flex justify-between gap-8">
 						<Link
+							href="/projects/2020"
+							className="duration-200 text-zinc-400 hover:text-zinc-100"
+						>
+							2020
+						</Link>
+						<Link
+							href="/projects/2021"
+							className="duration-200 text-zinc-400 hover:text-zinc-100"
+						>
+							2021
+						</Link>
+						<Link
+							href="/projects/2023"
+							className="duration-200 text-zinc-400 hover:text-zinc-100"
+						>
+							2023
+						</Link>
+						<Link
 							href="/projects"
 							className="duration-200 text-zinc-400 hover:text-zinc-100"
 						>
-							Projects
+							2024 Projects
 						</Link>
 						<Link
 							href="/contact"

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -2,6 +2,7 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
+import PastYearsDropdown from "./nav-dropdown";
 
 export const Navigation: React.FC = () => {
 	const ref = useRef<HTMLElement>(null);
@@ -28,30 +29,16 @@ export const Navigation: React.FC = () => {
 			>
 				<div className="container flex flex-row-reverse items-center justify-between p-6 mx-auto">
 					<div className="flex justify-between gap-8">
-						<Link
-							href="/projects/2020"
-							className="duration-200 text-zinc-400 hover:text-zinc-100"
-						>
-							2020
-						</Link>
-						<Link
-							href="/projects/2021"
-							className="duration-200 text-zinc-400 hover:text-zinc-100"
-						>
-							2021
-						</Link>
-						<Link
-							href="/projects/2023"
-							className="duration-200 text-zinc-400 hover:text-zinc-100"
-						>
-							2023
-						</Link>
+						<div className="flex gap-0.5 items-center group">
 						<Link
 							href="/projects"
-							className="duration-200 text-zinc-400 hover:text-zinc-100"
+							className="duration-200 text-zinc-400 group-hover:text-zinc-100"
 						>
-							2024 Projects
+							Projects
 						</Link>
+						<PastYearsDropdown />
+						</div>
+						
 						<Link
 							href="/contact"
 							className="duration-200 text-zinc-400 hover:text-zinc-100"

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -30,13 +30,13 @@ export const Navigation: React.FC = () => {
 				<div className="container flex flex-row-reverse items-center justify-between p-6 mx-auto">
 					<div className="flex justify-between gap-8">
 						<div className="flex gap-0.5 items-center group">
-						<Link
-							href="/projects"
-							className="duration-200 text-zinc-400 group-hover:text-zinc-100"
-						>
-							Projects
-						</Link>
-						<PastYearsDropdown />
+							<Link
+								href="/projects"
+								className="duration-200 text-zinc-400 group-hover:text-zinc-100"
+							>
+								Projects
+							</Link>
+							<PastYearsDropdown />
 						</div>
 						
 						<Link

--- a/app/projects/2020/page.tsx
+++ b/app/projects/2020/page.tsx
@@ -4,7 +4,7 @@ import ProjectsList from "../past-projects";
 
 const redis = Redis.fromEnv();
 
-const YEAR = 2022;
+const YEAR = 2020;
 
 export const revalidate = 60;
 export default async function ProjectsPage() {

--- a/app/projects/2021/page.tsx
+++ b/app/projects/2021/page.tsx
@@ -1,0 +1,34 @@
+import { Redis } from "@upstash/redis";
+import { allProjects } from "contentlayer/generated";
+import ProjectsList from "../past-projects";
+
+const redis = Redis.fromEnv();
+
+const YEAR = 2021;
+
+export const revalidate = 60;
+export default async function ProjectsPage() {
+  const views = (
+    await redis.mget<number[]>(
+      ...allProjects.map((p) => ["pageviews", "projects", p.slug].join(":"))
+    )
+  ).reduce((acc, v, i) => {
+    acc[allProjects[i].slug] = v ?? 0;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const sorted = allProjects
+    .filter((p) => p.published)
+    .filter(
+      (project) =>
+        // only include projects from this year
+        new Date(project.date ?? Number.POSITIVE_INFINITY).getFullYear() === YEAR
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.date ?? Number.POSITIVE_INFINITY).getTime() -
+        new Date(a.date ?? Number.POSITIVE_INFINITY).getTime()
+    );
+
+  return <ProjectsList views={views} projects={sorted} year={YEAR} />;
+}

--- a/app/projects/2022/page.tsx
+++ b/app/projects/2022/page.tsx
@@ -1,0 +1,34 @@
+import { Redis } from "@upstash/redis";
+import { allProjects } from "contentlayer/generated";
+import ProjectsList from "../past-projects";
+
+const redis = Redis.fromEnv();
+
+const YEAR = 2022;
+
+export const revalidate = 60;
+export default async function ProjectsPage() {
+  const views = (
+    await redis.mget<number[]>(
+      ...allProjects.map((p) => ["pageviews", "projects", p.slug].join(":"))
+    )
+  ).reduce((acc, v, i) => {
+    acc[allProjects[i].slug] = v ?? 0;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const sorted = allProjects
+    .filter((p) => p.published)
+    .filter(
+      (project) =>
+        // only include projects from this year
+        new Date(project.date ?? Number.POSITIVE_INFINITY).getFullYear() === YEAR
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.date ?? Number.POSITIVE_INFINITY).getTime() -
+        new Date(a.date ?? Number.POSITIVE_INFINITY).getTime()
+    );
+
+  return <ProjectsList views={views} projects={sorted} year={YEAR} />;
+}

--- a/app/projects/2023/page.tsx
+++ b/app/projects/2023/page.tsx
@@ -1,0 +1,34 @@
+import { Redis } from "@upstash/redis";
+import { allProjects } from "contentlayer/generated";
+import ProjectsList from "../past-projects";
+
+const redis = Redis.fromEnv();
+
+const YEAR = 2023;
+
+export const revalidate = 60;
+export default async function ProjectsPage() {
+  const views = (
+    await redis.mget<number[]>(
+      ...allProjects.map((p) => ["pageviews", "projects", p.slug].join(":"))
+    )
+  ).reduce((acc, v, i) => {
+    acc[allProjects[i].slug] = v ?? 0;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const sorted = allProjects
+    .filter((p) => p.published)
+    .filter(
+      (project) =>
+        // only include projects from this year
+        new Date(project.date ?? Number.POSITIVE_INFINITY).getFullYear() === YEAR
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.date ?? Number.POSITIVE_INFINITY).getTime() -
+        new Date(a.date ?? Number.POSITIVE_INFINITY).getTime()
+    );
+
+  return <ProjectsList views={views} projects={sorted} year={YEAR} />;
+}

--- a/app/projects/[slug]/header.tsx
+++ b/app/projects/[slug]/header.tsx
@@ -8,6 +8,7 @@ import {
   GlobeIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import React, { useEffect, useRef, useState } from "react";
 
 type Props = {
@@ -23,6 +24,7 @@ type Props = {
 export const Header: React.FC<Props> = ({ project, views }) => {
   const ref = useRef<HTMLElement>(null);
   const [isIntersecting, setIntersecting] = useState(true);
+  const router = useRouter()
 
   const links: { label: string; href: string; icon: React.ReactNode }[] = [];
   if (project.repository) {
@@ -96,8 +98,10 @@ export const Header: React.FC<Props> = ({ project, views }) => {
             </Link>
           </div>
 
-          <Link
-            href="/projects"
+          <button
+            type="button"
+            title="Go back" 
+            onClick={() => router.back()}
             className={`duration-200 hover:font-medium ${
               isIntersecting
                 ? " text-zinc-400 hover:text-zinc-100"
@@ -105,7 +109,7 @@ export const Header: React.FC<Props> = ({ project, views }) => {
             } `}
           >
             <ArrowLeft className="w-6 h-6 " />
-          </Link>
+          </button>
         </div>
       </div>
       <div className="container mx-auto relative isolate overflow-hidden  py-24 sm:py-32">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -9,6 +9,8 @@ import { Eye, GithubIcon } from "lucide-react";
 
 const redis = Redis.fromEnv();
 
+const YEAR = 2024;
+
 export const revalidate = 60;
 export default async function ProjectsPage() {
   const views = (
@@ -40,6 +42,8 @@ export default async function ProjectsPage() {
         project.slug !== featured.slug &&
         project.slug !== top2.slug &&
         project.slug !== top3.slug
+        // only include projects from this year
+        && new Date(project.date ?? Number.POSITIVE_INFINITY).getFullYear() === YEAR
     )
     .sort(
       (a, b) =>
@@ -57,7 +61,7 @@ export default async function ProjectsPage() {
           </h2>
           <p className="mt-4 text-zinc-400">
             Here are the winners of the Open Source Projects during Cebu
-            Hacktoberfest 2024...
+            Hacktoberfest {YEAR}...
           </p>
         </div>
 
@@ -151,7 +155,7 @@ export default async function ProjectsPage() {
           </h2>
           <p className="mt-4 text-zinc-400">
             These are the open source projects that were initiated during Cebu
-            Hacktoberfest 2024 opening day. See above list for winners...
+            Hacktoberfest {YEAR} opening day. See above list for winners...
           </p>
         </div>
 

--- a/app/projects/past-projects.tsx
+++ b/app/projects/past-projects.tsx
@@ -3,8 +3,6 @@ import { Navigation } from "@/app/components/nav";
 import { Article } from "@/app/projects/article";
 import type { Project } from "contentlayer/generated";
 
-export const revalidate = 60;
-
 interface ProjectListProps {
   year: number;
   views: Record<string, number>;

--- a/app/projects/past-projects.tsx
+++ b/app/projects/past-projects.tsx
@@ -1,0 +1,46 @@
+import { Card } from "@/app/components/card";
+import { Navigation } from "@/app/components/nav";
+import { Article } from "@/app/projects/article";
+import type { Project } from "contentlayer/generated";
+
+export const revalidate = 60;
+
+interface ProjectListProps {
+  year: number;
+  views: Record<string, number>;
+  projects: Project[];
+  // future ideas: support for hackathon winners, featured projects, etc.
+}
+
+export default async function ProjectsList({ year, views, projects }: ProjectListProps) {
+  return (
+    <div className="relative pb-16">
+      <Navigation />
+      <div className="px-6 pt-20 mx-auto space-y-8 max-w-7xl lg:px-8 md:space-y-16 md:pt-24 lg:pt-32">
+        <div className="max-w-4xl mx-auto lg:mx-0">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
+            Open Source Projects
+          </h2>
+          <p className="mt-4 text-zinc-400">
+            These are the open source projects that were showcased during Cebu Hacktoberfest {year}{" "}
+            opening day.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 mx-auto lg:mx-0 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, colIndex) => (
+            <div key={colIndex} className="grid grid-cols-1 gap-4">
+              {projects
+                .filter((_, i) => i % 3 === colIndex)
+                .map((project) => (
+                  <Card key={project.slug}>
+                    <Article project={project} views={views[project.slug] ?? 0} />
+                  </Card>
+                ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/content/projects/2020/dorellblog.mdx
+++ b/content/projects/2020/dorellblog.mdx
@@ -1,0 +1,9 @@
+---
+title: dorellblog
+description: Personal website
+repository: dorelljames/dorellblog
+date: "2020-10-17"
+published: true
+---
+
+Personal website by Dorell James.

--- a/content/projects/2020/endpoints.mdx
+++ b/content/projects/2020/endpoints.mdx
@@ -1,0 +1,9 @@
+---
+title: endpoints
+description: View and send custom responses to requests on HTTP endpoints
+repository: uncaughtxcptn/endpoints
+date: "2020-10-09"
+published: true
+---
+
+View and send custom responses to requests on HTTP endpoints

--- a/content/projects/2020/figma-dot-grid.mdx
+++ b/content/projects/2020/figma-dot-grid.mdx
@@ -1,0 +1,9 @@
+---
+title: figma-dot-grid
+description: Figma plugin for easily generating dot grids
+repository: arnellebalane/figma-dot-grid
+date: "2020-10-09"
+published: true
+---
+
+Figma plugin for easily generating dot grids

--- a/content/projects/2020/google-meet-pip.mdx
+++ b/content/projects/2020/google-meet-pip.mdx
@@ -1,0 +1,9 @@
+---
+title: google-meet-pip
+description: Chrome extension to display a selected Google Meet participant's video in a Picture-in-Picture window
+repository: arnellebalane/google-meet-pip
+date: "2020-10-09"
+published: true
+---
+
+Chrome extension to display a selected Google Meet participant's video in a Picture-in-Picture window

--- a/content/projects/2020/imgur-upload-cli.mdx
+++ b/content/projects/2020/imgur-upload-cli.mdx
@@ -1,0 +1,9 @@
+---
+title: imgur-upload-cli
+description: CLI for uploading images to imgur.com
+repository: arnellebalane/imgur-upload-cli
+date: "2020-10-09"
+published: true
+---
+
+CLI for uploading images to imgur.com

--- a/content/projects/2020/mdi-cli.mdx
+++ b/content/projects/2020/mdi-cli.mdx
@@ -1,0 +1,9 @@
+---
+title: mdi-cli
+description: Generate material design icons from the command line
+repository: arnellebalane/mdi-cli
+date: "2020-10-09"
+published: true
+---
+
+Generate material design icons from the command line

--- a/content/projects/2020/snippets.mdx
+++ b/content/projects/2020/snippets.mdx
@@ -1,0 +1,9 @@
+---
+title: snippets
+description: Host code snippets online
+repository: arnellebalane/snippets
+date: "2020-10-09"
+published: true
+---
+
+Host code snippets online

--- a/content/projects/2020/streaks.mdx
+++ b/content/projects/2020/streaks.mdx
@@ -1,0 +1,9 @@
+---
+title: streaks
+description: Keep track of anything using Github-style streaks
+repository: arnellebalane/streaks
+date: "2020-10-09"
+published: true
+---
+
+Keep track of anything using Github-style streaks

--- a/content/projects/2020/zio-netty.mdx
+++ b/content/projects/2020/zio-netty.mdx
@@ -1,0 +1,9 @@
+---
+title: zio-netty
+description: ZIO Bindings for Netty Java Library
+repository: akilegaspi/zio-netty
+date: "2020-10-17"
+published: true
+---
+
+ZIO Bindings for Netty Java Library

--- a/content/projects/2021/idpass-lite.mdx
+++ b/content/projects/2021/idpass-lite.mdx
@@ -1,0 +1,9 @@
+---
+title: idpass-lite
+description: A library to create and interact with secure and biometrically-binding QR code identity cards
+repository: idpass/idpass-lite
+date: "2021-10-06"
+published: true
+---
+
+A library to create and interact with secure and biometrically-binding QR code identity cards

--- a/content/projects/2021/quizshare.mdx
+++ b/content/projects/2021/quizshare.mdx
@@ -1,0 +1,9 @@
+---
+title: quizshare
+description: Create quizzes and share it with others
+repository: mjcarnaje/quizshare
+date: "2021-10-16"
+published: true
+---
+
+Create quizzes and share it with others

--- a/content/projects/2021/sanity-plugin-asset-source-pexels.mdx
+++ b/content/projects/2021/sanity-plugin-asset-source-pexels.mdx
@@ -1,0 +1,9 @@
+---
+title: sanity-plugin-asset-source-pexels
+description: Use Pexels.com as media source for Sanity Studio
+repository: dorelljames/sanity-plugin-asset-source-pexels
+date: "2021-10-06"
+published: true
+---
+
+Use Pexels.com as media source for Sanity Studio

--- a/content/projects/2021/sanity-plugin-netlify-deploy-status-badge.mdx
+++ b/content/projects/2021/sanity-plugin-netlify-deploy-status-badge.mdx
@@ -1,0 +1,9 @@
+---
+title: sanity-plugin-netlify-deploy-status-badge
+description: Display Netlify's status badge in Sanity Studio and your site's recent deploys. Plus, trigger a new build if you want to!
+repository: dorelljames/sanity-plugin-netlify-deploy-status-badge
+date: "2021-10-06"
+published: true
+---
+
+Display Netlify's status badge in Sanity Studio and your site's recent deploys. Plus, trigger a new build if you want to!

--- a/content/projects/2021/smartscanner-capacitor.mdx
+++ b/content/projects/2021/smartscanner-capacitor.mdx
@@ -1,0 +1,9 @@
+---
+title: smartscanner-capacitor
+description: Capacitor plugin for the SmartScanner Core library to scan MRZ, NFC and barcodes
+repository: idpass/smartscanner-capacitor
+date: "2021-10-06"
+published: true
+---
+
+Capacitor plugin for the SmartScanner Core library to scan MRZ, NFC and barcodes

--- a/content/projects/2021/smartscanner-cordova.mdx
+++ b/content/projects/2021/smartscanner-cordova.mdx
@@ -1,0 +1,9 @@
+---
+title: smartscanner-cordova
+description: Cordova plugin for the SmartScanner Core library to scan MRZ, NFC and barcodes
+repository: idpass/smartscanner-cordova
+date: "2021-10-06"
+published: true
+---
+
+Cordova plugin for the SmartScanner Core library to scan MRZ, NFC and barcodes

--- a/content/projects/2021/smartscanner-core.mdx
+++ b/content/projects/2021/smartscanner-core.mdx
@@ -1,0 +1,9 @@
+---
+title: smartscanner-core
+description: ID scanning Android app and library. Supports MRZ, NFC, Barcodes, and ID PASS Lite cards.
+repository: idpass/smartscanner-core
+date: "2021-10-06"
+published: true
+---
+
+ID scanning Android app and library. Supports MRZ, NFC, Barcodes, and ID PASS Lite cards.

--- a/content/projects/2021/toolpress.mdx
+++ b/content/projects/2021/toolpress.mdx
@@ -1,0 +1,9 @@
+---
+title: toolpress
+description: ToolPress is a Next.js app to display a list of tools (posts) from WordPress
+repository: laxmariappan/toolpress
+date: "2021-10-09"
+published: true
+---
+
+ToolPress is a Next.js app to display a list of tools (posts) from WordPress

--- a/content/projects/2023/awesome-cloud-cost-control.mdx
+++ b/content/projects/2023/awesome-cloud-cost-control.mdx
@@ -1,0 +1,9 @@
+---
+title: awsome-cloud-cost-control
+description: Curated list of cloud cost control resources
+repository: Funkmyster/awesome-cloud-cost-control
+date: "2023-10-23"
+published: true
+---
+
+A curated list of awesome cloud cost control blogs, podcasts, standards, projects, and examples

--- a/content/projects/2023/awesome-cloud-security.mdx
+++ b/content/projects/2023/awesome-cloud-security.mdx
@@ -1,0 +1,9 @@
+---
+title: awesome-cloud-security
+description: Curated list of cloud security resources
+repository: Funkmyster/awesome-cloud-security
+date: "2023-10-23"
+published: true
+---
+
+A curated list of awesome cloud security blogs, podcasts, standards, projects, and examples

--- a/content/projects/2023/awesome-supply-chain.mdx
+++ b/content/projects/2023/awesome-supply-chain.mdx
@@ -1,0 +1,9 @@
+---
+title: awesome-supply-chain
+description: Curated list of supply chain resources
+repository: Funkmyster/awesome-supply-chain
+date: "2023-10-23"
+published: true
+---
+
+A curated list of awesome supply chain blogs, podcasts, standards, projects, and examples

--- a/content/projects/2023/casaos-appstore-generator.mdx
+++ b/content/projects/2023/casaos-appstore-generator.mdx
@@ -1,0 +1,9 @@
+---
+title: casaos-appstore-generator
+description: Appstore generator for CasaOS supporting multiple container registries
+repository: WisdomSky/CasaOS-Cool-Appstore-Generator
+date: "2023-10-21"
+published: true
+---
+
+Appstore generator for CasaOS supporting dockerhub and github packages container registries

--- a/content/projects/2023/casaos-toolbox.mdx
+++ b/content/projects/2023/casaos-toolbox.mdx
@@ -1,0 +1,9 @@
+---
+title: casaos-toolbox
+description: Additional features for CasaOS dashboard management
+repository: WisdomSky/CasaOS-Toolbox
+date: "2023-10-21"
+published: true
+---
+
+Additional features for CasaOS including dashboard element management and access control

--- a/content/projects/2023/chessu.mdx
+++ b/content/projects/2023/chessu.mdx
@@ -1,0 +1,9 @@
+---
+title: chessu
+description: Online multiplayer chess web app.
+repository: dotnize/chessu
+date: "2023-10-09"
+published: true
+---
+
+Online multiplayer chess web app.

--- a/content/projects/2023/cloudflared-web.mdx
+++ b/content/projects/2023/cloudflared-web.mdx
@@ -1,0 +1,9 @@
+---
+title: cloudflared-web
+description: Docker image for managing Cloudflare Tunnel via web UI
+repository: WisdomSky/Cloudflared-web
+date: "2023-10-21"
+published: true
+---
+
+Docker image that packages both Cloudflared CLI and a UI for managing Cloudflare Tunnel via web browser

--- a/content/projects/2023/interior-designer-ai.mdx
+++ b/content/projects/2023/interior-designer-ai.mdx
@@ -1,0 +1,9 @@
+---
+title: interior-designer-ai
+description: AI-powered room design generator
+repository: siegblink/interior-designer-ai
+date: "2023-10-21"
+published: true
+---
+
+Upload a sample room photo and get a design back in seconds

--- a/content/projects/2023/langcontrol.mdx
+++ b/content/projects/2023/langcontrol.mdx
@@ -1,0 +1,9 @@
+---
+title: LangControl
+description: LLM API and workflow management tool
+repository: RegulatedCloud/LangControl
+date: "2023-10-23"
+published: true
+---
+
+Quickly create and control your LLM api and workflow

--- a/content/projects/2023/pkgx-ossapp.mdx
+++ b/content/projects/2023/pkgx-ossapp.mdx
@@ -1,0 +1,9 @@
+---
+title: ossapp
+description: Streamlined package installation interface
+repository: pkgxdev/ossapp
+date: "2023-10-23"
+published: true
+---
+
+Query expansive pkgdb and install desired package versions with one click

--- a/content/projects/2023/pkgx-pantry.mdx
+++ b/content/projects/2023/pkgx-pantry.mdx
@@ -1,0 +1,9 @@
+---
+title: pantry
+description: Build library for pkgx packages
+repository: pkgxdev/pantry
+date: "2023-10-23"
+published: true
+---
+
+Build library of all packages pkgx enables user to install

--- a/content/projects/2023/pkgx.mdx
+++ b/content/projects/2023/pkgx.mdx
@@ -1,0 +1,9 @@
+---
+title: pkgx
+description: Next-gen cross-platform package manager
+repository: pkgxdev/pkgx
+date: "2023-10-23"
+published: true
+---
+
+Blazingly fast, standalone, cross‐platform binary that runs anything

--- a/content/projects/2023/rize-opensource.mdx
+++ b/content/projects/2023/rize-opensource.mdx
@@ -1,0 +1,9 @@
+---
+title: rize-opensource
+description: Simple app for streamlining workplace tasks with MongoDB integration
+repository: HEYYOUDAREL/rize-opensource
+date: "2023-10-11"
+published: true
+---
+
+Simple app for streamlining workplace tasks with MongoDB integration

--- a/content/projects/2023/stacks.mdx
+++ b/content/projects/2023/stacks.mdx
@@ -1,0 +1,9 @@
+---
+title: stacks
+description: Type-safe full-stack framework for Artisans
+repository: stacksjs/stacks
+date: "2023-10-23"
+published: true
+---
+
+Type-safe full-stack framework for developing modern clouds, apps & framework-agnostic libraries

--- a/content/projects/2023/weavedb.mdx
+++ b/content/projects/2023/weavedb.mdx
@@ -1,0 +1,9 @@
+---
+title: weavedb
+description: Decentralized NoSQL Database as a smart contract on Arweave
+repository: weavedb/weavedb
+date: "2023-10-09"
+published: true
+---
+
+Decentralized NoSQL Database as a smart contract on Arweave

--- a/content/projects/varo-dev.mdx
+++ b/content/projects/varo-dev.mdx
@@ -11,7 +11,7 @@ This is an experimental project exploring how we can utilize AI and LLMs in our 
 
 ## Team Mugnavo
 
-- 👨‍💻 Nathaniel John Tampus (Lead) → [dotnize](https://github.com/dotniz)
+- 👨‍💻 Nathaniel John Tampus (Lead) → [dotnize](https://github.com/dotnize)
 - 🧑‍💻 Josh Kenshi Dimpas → [JoshCunningHum](https://github.com/JoshCunningHum)
 - 🧑‍💻 Khent Harold Amancio → [haerld](https://github.com/haerld)
 - 🧑‍💻 Marion Emmanuel Buhat → [Peroxidize](https://github.com/Peroxidize)

--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -12,7 +12,7 @@ const computedFields = {
   },
   slug: {
     type: "string",
-    resolve: (doc) => doc._raw.flattenedPath.split("/").slice(1).join("/"),
+    resolve: (doc) => doc._raw.flattenedPath.split("/").pop() // use last part of the path to also exclude year
   },
 };
 


### PR DESCRIPTION
closes #1

Changes:

- [x] Updated contentlayer config to use only last part of path as slug. This excludes the year from the slug for past projects (`projects/2023/hello` -> `/hello`). Previous behavior only excluded `/projects` since we didn't have the year yet.
- [x] Updated current projects page to use a `YEAR` constant for easier future changes, and only include projects from that year (currently 2024).
- [x] Reusable projects list component (`past-projects.tsx`) currently only for previous years.
- [x] Use router.back() in project view header instead of fixed `/projects` Link, to support previous year pages
- [x] Add previous years to nav via hover dropdown
- [x] Add the previous projects from the spreadsheet


Future ideas

- Add support for categorized projects (e.g. hackathon winners, top/featured projects, etc.) in `past-projects.tsx` component, similar to the current projects page.
  - and re-use this component for the current year projects for less redundancy.
 
Let me know if any adjustments or changes are needed!