### PR TITLE
fix(404): replace back arrow with home icon on Go Home button #36

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { NavWrapper } from "./components/nav-wrapper";
 import { Footer } from "./components/footer";
-import { Home, ArrowLeft } from "lucide-react";
+import { Home } from "lucide-react";
 import Particles from "./components/particles";
 
 export default function NotFound() {
@@ -38,8 +38,8 @@ export default function NotFound() {
               href="/"
               className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-lavender text-void rounded-md font-medium hover:bg-melrose transition-colors"
             >
-              <ArrowLeft className="w-4 h-4" />
-              Go Home
+              <Home className="w-4 h-4" />
+              Home
             </Link>
 
             <Link


### PR DESCRIPTION
# Update 404 Page: Replace Back Arrow with Home Icon

## Description
Updated the "Go Home" button on the 404 page to use a Home icon instead of ArrowLeft icon for better semantic clarity.

## Changes
- Replaced `ArrowLeft` icon with `Home` icon from lucide-react
- More intuitive icon for returning to homepage
- Removed unused ArrowLeft import

## Files Changed
- `app/not-found.tsx`

## Testing
- [ ] Visit `/non-existent-page` to see 404
- [ ] Verify Home icon displays correctly
- [ ] Click "Go Home" button navigates to homepage
- [ ] Responsive on mobile/desktop

Closes #27 