### PR TITLE
feat(projects): add Hackathon winners section with WinnersCard component

### DIFF
--- a/app/components/winners-card.tsx
+++ b/app/components/winners-card.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { Card } from "./card";
+
+export type WinnerProject = {
+  id: string;
+  title: string;
+  description: string;
+  repository: string;
+  submittedAt: string;
+  status: string;
+  year: number;
+};
+
+type WinnersCardProps = {
+  winner: WinnerProject;
+  badge: string;
+  badgeColor: string;
+  size?: "large" | "medium";
+};
+
+export function WinnersCard({ winner, badge, badgeColor, size = "medium" }: WinnersCardProps) {
+  const isLarge = size === "large";
+
+  return (
+    <Card>
+      <Link href={`/projects/submitted/${winner.id}`}>
+        <article className={`relative w-full h-full p-4 md:p-8`}>
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-xs text-zinc-100">
+              {winner.submittedAt ? (
+                <time dateTime={new Date(winner.submittedAt).toISOString()}>
+                  {Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+                    new Date(winner.submittedAt)
+                  )}
+                </time>
+              ) : (
+                <span>SOON</span>
+              )}
+              <span className={`ml-2 text-xs text-zinc-100 ${badgeColor} px-2 py-1 rounded-md`}>
+                {badge}
+              </span>
+            </div>
+          </div>
+
+          <h2
+            className={`mt-4 font-bold text-zinc-100 group-hover:text-white font-display ${
+              isLarge ? "text-3xl sm:text-4xl" : "text-xl sm:text-2xl"
+            }`}
+          >
+            {winner.title}
+          </h2>
+          <p
+            className={`mt-2 text-zinc-400 group-hover:text-zinc-300 ${
+              isLarge ? "mt-4 leading-8" : "line-clamp-3"
+            }`}
+          >
+            {winner.description}
+          </p>
+
+        </article>
+      </Link>
+    </Card>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -16,6 +16,9 @@ import React from "react";
 import { allProjects } from "contentlayer/generated";
 import { SubmittedProjectCard } from "./submitted-project-card";
 import { ContributionCard } from "./contribution-card";
+import { WinnersCard } from "../components/winners-card";
+
+import { GithubIcon } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Open Source Projects",
@@ -73,122 +76,161 @@ export default async function ProjectsPage() {
   );
   const existingProjects = deduplicateProjects(existingProjectsRaw);
 
+  // Determine winners from submitted hackathon projects (fall back to placeholders)
   const winners = {
-    top1: allProjects.find((project) => project.slug === "empty")!,
-    top2: allProjects.find((project) => project.slug === "empty")!,
-    top3: allProjects.find((project) => project.slug === "empty")!,
+      BestOverall: hackathonProjects.find((p) => p.title.toLowerCase().includes("totoo ba ito")) || {
+        id: "placeholder-1",
+        title: "Totoo Ba Ito?",
+        description: "An AI-powered Product and Industry Verification Checker using the official FDA Datasets",
+        repository: "https://github.com/Neil-urk12/totoo-ba",
+        submittedAt: "October 22, 2025",
+        status: "approved",
+        year: 2025,
+      },
+      BestBlockchain: hackathonProjects.find((p) => p.title.toLowerCase().includes("barangay konek")) || {
+          id: "placeholder-blockchain",
+          title: "Barangay Konek",
+          description: "Barangay Konek revolutionizes barangay services through AI and blockchain, bringing convenience, transparency, and accessibility to every Filipino.",
+          repository: "https://github.com/robwilsoncaldosa/barangay-konek",
+          submittedAt: "October 11, 2025",
+          status: "approved",
+          year: 2025,
+      },
+      BestAI: hackathonProjects.find((p) => p.title.toLowerCase().includes("quiz attack")) || {
+        id: "placeholder-2",
+        title: "Quiz Attack - AI-Powered Quiz Battles",
+        description: "A competitive 1v1 quiz battle web app where students challenge each other using AI-generated lectures and quizzes. Built with React, Firebase, and Google Gemini.",
+        repository: "https://github.com/EdocEdoc/quiz-atk-prj",
+        submittedAt: "October 10, 2025",
+        status: "approved",
+        year: 2025,
+      },
+      BestEasterEgg: hackathonProjects.find((p) => p.title.toLowerCase().includes("bayanihancebu")) || {
+        id: "placeholder-3",
+        title: "BayanihanCebu",
+        description: "BayanihanCebu is a blockchain-powered disaster relief platform that enhances transparency, coordination, and accountability during calamities in Cebu. By integrating Laravel’s robust backend with Lisk blockchain technology, it ensures that every donation, request, and transaction is traceable and tamper-proof. This system streamlines coordination among barangays, BDRRMC, and LDRRMO—eliminating duplication, reducing delays, and rebuilding public trust in disaster response operations.",
+        repository: "https://github.com/chelsepit/BayanihanCebu.git",
+        submittedAt: "October 24, 2025",
+        status: "approved",
+        year: 2025,
+      },
+    };
+  
+  
+    const currentYearProjects = getProjectsByYear(allProjects, YEAR);
+    const sorted = hackathonProjects.filter(
+      (project) =>
+        project.id !== winners.BestOverall.id &&
+        project.id !== winners.BestAI.id &&
+        project.id !== winners.BestEasterEgg.id &&
+        project.id !== winners.BestBlockchain.id
+    );
+  
+
+  // For open-source contribution winner we keep a placeholder until announced
+  const contributionWinner = {
+    id: "placeholder-contrib",
+    title: "To Be Announced",
+    description: "Best Open Source Contribution - Winner will be announced soon.",
+    repository: "#",
+    submittedAt: new Date().toISOString(),
+    status: "pending",
+    year: YEAR,
   };
 
-  const featured = allProjects.find((project) => project.slug === "cebby")!;
-  const top2 = allProjects.find((project) => project.slug === "empty")!;
-  const top3 = allProjects.find((project) => project.slug === "empty")!;
-  const currentYearProjects = getProjectsByYear(allProjects, YEAR);
-  const sorted = currentYearProjects.filter(
-    (project) =>
-      project.slug !== featured.slug &&
-      project.slug !== top2.slug &&
-      project.slug !== top3.slug
-  );
+
+  // Featured projects from contentlayer (local developers' projects)
+  const featured = allProjects
+    .filter((project) => project.published)
+    .sort((a, b) => {
+      if (new Date(a.date ?? Number.POSITIVE_INFINITY).getTime() > new Date(b.date ?? Number.POSITIVE_INFINITY).getTime()) {
+        return -1;
+      }
+      return 1;
+    })[0];
+
+  const BestBlockchain = allProjects
+    .filter((project) => project.published)
+    .sort((a, b) => {
+      if (new Date(a.date ?? Number.POSITIVE_INFINITY).getTime() > new Date(b.date ?? Number.POSITIVE_INFINITY).getTime()) {
+        return -1;
+      }
+      return 1;
+    })[1];
+
+  const BestAI = allProjects
+    .filter((project) => project.published)
+    .sort((a, b) => {
+      if (new Date(a.date ?? Number.POSITIVE_INFINITY).getTime() > new Date(b.date ?? Number.POSITIVE_INFINITY).getTime()) {
+        return -1;
+      }
+      return 1;
+    })[2];
 
   return (
     <div className="relative pb-16">
       <NavWrapper />
       <div className="px-6 pt-20 mx-auto space-y-8 max-w-7xl lg:px-8 md:space-y-16 md:pt-24 lg:pt-32">
-        {/* <div className="max-w-4xl mx-auto lg:mx-0 hidden">
+        {/* Winners Section (highlight hackathon winners) */}
+        <div className="max-w-4xl mx-auto lg:mx-0">
           <h2 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
-            Open Source Projects Winners
+            Hackathon Winners
           </h2>
           <p className="mt-4 text-zinc-400">
-            Here are the winners of the Open Source Projects during Cebu
-            Hacktoberfest {YEAR}...
+            Congratulations to the winners of the Hacktoberfest {YEAR} hackathon track!
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-8 mx-auto lg:grid-cols-2  hidden">
-          <Card>
-            <Link href={`/projects/${winners.top1.slug}`}>
-              <article className="relative w-full h-full p-4 md:p-8">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-xs text-zinc-100">
-                    {winners.top1.date ? (
-                      <time
-                        dateTime={new Date(winners.top1.date).toISOString()}
-                      >
-                        {Intl.DateTimeFormat(undefined, {
-                          dateStyle: "medium",
-                        }).format(new Date(winners.top1.date))}
-                      </time>
-                    ) : (
-                      <span>SOON</span>
-                    )}
-                    <span className="ml-2 text-xs text-zinc-100 bg-green-900 px-2 py-1 rounded-md">
-                      Best Overall Project
-                    </span>
-                  </div>
-                  <span className="flex items-center gap-1 text-xs text-zinc-500">
-                    <Eye className="w-4 h-4" />{" "}
-                    {Intl.NumberFormat("en-US", { notation: "compact" }).format(
-                      views[winners.top1.slug] ?? 0
-                    )}
-                  </span>
-                </div>
+        <div className="grid grid-cols-1 gap-8 mx-auto lg:grid-cols-2">
+          {/* Best Overall Project - Large Featured Card */}
+          <WinnersCard
+            winner={winners.BestOverall}
+            badge="🏆 Best Overall Project"
+            badgeColor="bg-green-900"
+            size="large"
+          />
 
-                <h2
-                  id="winners.top1-post"
-                  className="mt-4 text-3xl font-bold text-zinc-100 group-hover:text-white sm:text-4xl font-display"
-                >
-                  {winners.top1.title}
-                </h2>
-                <p className="mt-4 leading-8 duration-150 text-zinc-400 group-hover:text-zinc-300">
-                  {winners.top1.description}
-                </p>
-                <div className="absolute bottom-4 md:bottom-8">
-                  <p className="hidden text-zinc-200 hover:text-zinc-50 lg:block">
-                    Read more <span aria-hidden="true">&rarr;</span>
-                  </p>
-                </div>
-              </article>
-            </Link>
-          </Card>
+          {/* Best Use of Blockchain - Large Card */}
+          <WinnersCard
+            winner={winners.BestBlockchain}
+            badge="⛓️ Best Use of Blockchain"
+            badgeColor="bg-orange-900"
+            size="large"
+          />
 
-          <div className="flex flex-col w-full gap-8 mx-auto border-t border-gray-900/10 lg:mx-0 lg:border-t-0 ">
-            {[winners.top2, winners.top3].map((project) => (
-              <Card key={project.slug}>
-                <Article
-                  project={project}
-                  views={views[project.slug] ?? 0}
-                  badge={
-                    project.slug === winners.top2.slug
-                      ? "Best Use of AI"
-                      : "Most Fun / Best Easter Egg"
-                  }
-                />
-              </Card>
-            ))}
-          </div>
+          {/* Best Use of AI - Medium Card */}
+          <WinnersCard
+            winner={winners.BestAI}
+            badge="🤖 Best Use of AI"
+            badgeColor="bg-blue-900"
+            size="medium"
+          />
+
+          {/* Best Easter Egg - Medium Card */}
+          <WinnersCard
+            winner={winners.BestEasterEgg}
+            badge="🎉 Best Easter Egg"
+            badgeColor="bg-purple-900"
+            size="medium"
+          />
         </div>
 
-        <Card key={featured.slug}>
-          <Link href={"https://github.com/dorelljames/event-ni/pull/5"}>
-            <div className="mt-2 flex items-center justify-between gap-2">
-              <span className="ml-2 text-xs text-zinc-100 bg-green-900 px-2 py-1 rounded-md">
-                Best Overall Contribution
-              </span>
-            </div>
+        
+        <Card>
+          <Link href="#">
             <article className="p-4 md:p-8">
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <span className="ml-2 text-xs text-zinc-100 bg-green-900 px-2 py-1 rounded-md">🌟 Best Open Source Contribution</span>
+              </div>
               <h2 className="mt-2 z-20 text-xl font-medium duration-1000 lg:text-2xl text-zinc-200 group-hover:text-white font-display">
                 <div className="flex items-center justify-center gap-2">
-                  <h2>Coming soon</h2>
-                  <span className="text-zinc-400">
-                    who will this year's winner be?
-                  </span>
+                  <GithubIcon /> {contributionWinner.title}
                 </div>
               </h2>
+              <p className="mt-4 text-zinc-400 text-center">{contributionWinner.description}</p>
             </article>
           </Link>
         </Card>
-
-        <div className="hidden w-full h-px md:block bg-zinc-800" /> */}
 
         {/* Hackathon Projects Section */}
         {hackathonProjects.length > 0 && (
@@ -337,7 +379,7 @@ export default async function ProjectsPage() {
           </Card>
 
           <div className="flex flex-col w-full gap-8 mx-auto border-t border-gray-900/10 lg:mx-0 lg:border-t-0 ">
-            {[top2, top3].map((project) => (
+            {[BestBlockchain, BestAI].map((project) => (
               <Card key={project.slug}>
                 <Article project={project} views={views[project.slug] ?? 0} />
               </Card>

--- a/docs/HACKATHON_WINNERS.md
+++ b/docs/HACKATHON_WINNERS.md
@@ -1,0 +1,403 @@
+# Adding Hackathon Winners to Projects Page
+
+## Overview
+
+This document describes the implementation of the **Hackathon Winners** section on the main Projects page (`app/projects/page.tsx`) that highlights the winners of the Hacktoberfest 2025 hackathon track. Winner cards redirect to project detail pages instead of external GitHub links.
+
+## Summary of Changes
+
+### What Was Added
+- ✅ `WinnersCard` component (`app/components/winners-card.tsx`) - Reusable card component for displaying winners
+- ✅ Winners section at the top of `/projects` page
+- ✅ Automatic winner discovery from approved submitted hackathon projects
+- ✅ Winner exclusion from regular hackathon projects listing (no duplication)
+- ✅ Placeholder for contribution track winner (to be announced)
+- ✅ All winner cards redirect to `/projects/submitted/[id]` (not GitHub)
+
+### Files Created/Modified
+- `app/components/winners-card.tsx` - New reusable component for winner cards
+- `app/projects/page.tsx` - Added winners section logic and rendering
+- `docs/HACKATHON_WINNERS.md` - This documentation file
+
+---
+
+## Component Details
+
+### WinnersCard Component
+
+**Location:** `app/components/winners-card.tsx`
+
+A reusable client component that displays winner project cards with customizable styling.
+
+**Props:**
+```typescript
+type WinnersCardProps = {
+  winner: WinnerProject;      // Project data object
+  badge: string;              // Badge text (e.g., "🏆 Best Overall Project")
+  badgeColor: string;         // Tailwind class (e.g., "bg-green-900")
+  size?: "large" | "medium";  // Card size variant (default: "medium")
+};
+
+type WinnerProject = {
+  id: string;
+  title: string;
+  description: string;
+  repository: string;
+  submittedAt: string;
+  status: string;
+  year: number;
+};
+```
+
+**Features:**
+- Two size variants: `large` (featured winners) and `medium` (other categories)
+- Automatic date formatting with Intl.DateTimeFormat
+- Links to `/projects/submitted/[id]` for viewing full project details
+- Hover effects for better UX
+- Responsive design
+
+**Usage Example:**
+```tsx
+<WinnersCard
+  winner={winners.BestOverall}
+  badge="🏆 Best Overall Project"
+  badgeColor="bg-green-900"
+  size="large"
+/>
+```
+
+---
+
+## Winners Section Layout
+
+The winners section on `/projects` displays in a 2-column grid:
+
+### Grid Layout:
+1. **Best Overall Project** (🏆) - Large card (top left)
+2. **Best Use of Blockchain** (⛓️) - Large card (top right)
+3. **Best Use of AI** (🤖) - Medium card (bottom left)
+4. **Best Easter Egg** (🎉) - Medium card (bottom right)
+5. **Best Open Source Contribution** (🌟) - Full-width placeholder card (below grid)
+
+### Badge Colors:
+- Best Overall: `bg-green-900` 🏆
+- Best Use of Blockchain: `bg-orange-900` ⛓️
+- Best Use of AI: `bg-blue-900` 🤖
+- Best Easter Egg: `bg-purple-900` 🎉
+- Best Open Source Contribution: `bg-green-900` 🌟
+
+---
+
+## How Winners Are Determined
+
+The page automatically searches for winners in approved submitted hackathon projects using **title matching**:
+
+```typescript
+const winners = {
+  BestOverall: hackathonProjects.find((p) => 
+    p.title.toLowerCase().includes("totoo ba to")
+  ) || { /* placeholder */ },
+  
+  BestBlockchain: hackathonProjects.find((p) => 
+    p.title.toLowerCase().includes("barangay konek")
+  ) || { /* placeholder */ },
+  
+  BestAI: hackathonProjects.find((p) => 
+    p.title.toLowerCase().includes("quiz attack")
+  ) || { /* placeholder */ },
+  
+  BestEasterEgg: hackathonProjects.find((p) => 
+    p.title.toLowerCase().includes("bayanihancebu")
+  ) || { /* placeholder */ },
+};
+```
+
+### Search Criteria:
+- **Best Overall**: Title contains "totoo ba to"
+- **Best Use of Blockchain**: Title contains "barangay konek"
+- **Best Use of AI**: Title contains "quiz attack"
+- **Best Easter Egg**: Title contains "bayanihancebu"
+- **Best Open Source Contribution**: Currently a placeholder ("To Be Announced")
+
+If a winner project is not found in submissions, placeholder data with basic info is displayed.
+
+---
+
+## Winner Exclusion from Regular Listing
+
+Winners are **automatically excluded** from the "Hackathon Projects" section to avoid duplication:
+
+```typescript
+const sorted = hackathonProjects.filter(
+  (project) =>
+    project.id !== winners.BestOverall.id &&
+    project.id !== winners.BestAI.id &&
+    project.id !== winners.BestEasterEgg.id &&
+    project.id !== winners.BestBlockchain.id
+);
+```
+
+This ensures each winning project appears only once on the page.
+
+---
+
+## How to Update Winners
+
+### Option 1: Update Via Approved Submissions (Recommended ✅)
+
+The easiest way is to ensure the winning projects are:
+1. Submitted via the `/submit` page
+2. Approved in the admin panel
+3. Have titles matching the search criteria above
+
+The page will automatically find and display them.
+
+### Option 2: Update the Code Directly
+
+**To change which projects are featured as winners:**
+
+1. Open `app/projects/page.tsx`
+2. Locate the `winners` object (around line 85-125)
+3. Update the title matching logic or replace with specific project IDs
+
+**Example - Changing the search term:**
+```typescript
+BestOverall: hackathonProjects.find((p) => 
+  p.title.toLowerCase().includes("new winner title")  // Change this
+) || { /* placeholder */ },
+```
+
+**Example - Using specific project ID:**
+```typescript
+BestOverall: hackathonProjects.find((p) => 
+  p.id === "specific-submission-id"  // Use exact ID
+) || { /* placeholder */ },
+```
+
+### Option 3: Update Placeholders
+
+If a winning project hasn't been submitted yet, update the placeholder fallback data:
+
+```typescript
+const winners = {
+  BestOverall: hackathonProjects.find((p) => 
+    p.title.toLowerCase().includes("totoo ba to")
+  ) || {
+    id: "placeholder-1",
+    title: "Your Winner Title Here",          // ← Update
+    description: "Winner description here.",   // ← Update
+    repository: "https://github.com/winner/repo", // ← Update
+    submittedAt: "October 22, 2025",          // ← Update
+    status: "approved",
+    year: 2025,
+  },
+};
+```
+
+### Option 4: Update Contribution Winner
+
+Once the contribution track winner is announced:
+
+1. Open `app/projects/page.tsx`
+2. Find the `contributionWinner` object (around line 134)
+3. Replace placeholder with actual winner data:
+
+```typescript
+const contributionWinner = {
+  id: "actual-contrib-id",  // Real submission ID
+  title: "Actual Winner Title",
+  description: "Description of the contribution",
+  repository: "#",  // Or link to PR
+  submittedAt: new Date("2025-10-20").toISOString(),
+  status: "approved",
+  year: YEAR,
+};
+```
+
+---
+
+## File Structure
+
+```
+app/
+├── components/
+│   └── winners-card.tsx         ← New reusable component
+├── projects/
+    └── page.tsx                 ← Main projects page
+        ├── Winners Section (lines ~185-215)
+        │   ├── Best Overall (WinnersCard large)
+        │   ├── Best Blockchain (WinnersCard large)
+        │   ├── Best AI (WinnersCard medium)
+        │   ├── Best Easter Egg (WinnersCard medium)
+        │   └── Best Contribution (placeholder Card)
+        ├── Hackathon Projects Section (excluding winners)
+        ├── Existing Projects Section
+        ├── Community Contributions Section
+        └── Featured Projects Section (contentlayer)
+```
+
+---
+
+## Testing Checklist
+
+After making changes, verify:
+
+- [ ] **Winners appear at the top** of `/projects` page
+- [ ] **Correct badges and colors** display for each winner
+- [ ] **No duplicate projects** - winners should NOT appear in "Hackathon Projects" section
+- [ ] **Links work correctly** - clicking winner cards navigates to `/projects/submitted/[id]`
+- [ ] **Placeholders display** properly if a winner isn't found in submissions
+- [ ] **Responsive layout** - looks good on mobile, tablet, and desktop viewports
+- [ ] **Hover effects** work smoothly on winner cards
+- [ ] **Contribution winner** shows "To Be Announced" placeholder
+- [ ] **TypeScript compiles** without errors
+
+---
+
+## Technical Notes
+
+- **Server-side rendered**: Winners data is fetched on the server with `revalidate = 60` (updates every 60 seconds)
+- **Client component**: `WinnersCard` is a client component for interactive hover effects
+- **Next.js Link**: All cards use `<Link>` for optimized client-side navigation
+- **Type safety**: TypeScript types ensure correct prop usage
+- **Badge customization**: Each category has distinct colors and emojis for visual hierarchy
+
+---
+
+## Pull Request Template
+
+### PR Title
+```
+feat: Add Hackathon Winners section with WinnersCard component
+```
+
+### PR Description
+```markdown
+## 📝 Summary
+
+Adds a prominent **Hackathon Winners** section to `/projects` with a new reusable `WinnersCard` component. All winner cards redirect to project detail pages.
+
+## ✨ Changes
+
+### New Component
+- ✅ Created `WinnersCard` component (`app/components/winners-card.tsx`)
+  - Reusable card with customizable badge, color, and size
+  - Two size variants: large and medium
+  - Links to `/projects/submitted/[id]` instead of GitHub
+
+### Main Changes
+- ✅ Added winners section at top of `/projects` page
+- ✅ Automatically discovers winners from approved submissions via title matching
+- ✅ Excludes winners from regular hackathon listing (no duplication)
+- ✅ Added placeholder for contribution winner (to be announced)
+
+### Winners Displayed
+1. 🏆 **Best Overall Project** - "Totoo Ba Ito?"
+2. ⛓️ **Best Use of Blockchain** - "Barangay Konek"
+3. 🤖 **Best Use of AI** - "Quiz Attack"
+4. 🎉 **Best Easter Egg** - "BayanihanCebu"
+5. 🌟 **Best Open Source Contribution** - Placeholder
+
+## 🎯 How It Works
+
+- Searches approved hackathon submissions by title matching
+- Falls back to placeholders if winners not found
+- Automatically excludes winners from regular listing
+- All cards link to project detail pages
+
+## 🧪 Testing Steps
+
+1. Navigate to `/projects`
+2. Verify winners appear at top with correct badges/colors
+3. Confirm NO duplicates in "Hackathon Projects" section
+4. Click winner cards → should go to `/projects/submitted/[id]`
+5. Test responsive layout (mobile/tablet/desktop)
+6. Verify contribution winner shows "To Be Announced"
+
+## 📚 Documentation
+
+See `docs/HACKATHON_WINNERS.md` for:
+- Component API reference
+- How to update winners
+- Testing checklist
+- Technical implementation details
+
+---
+
+Closes #[issue-number]
+```
+
+---
+
+## Issue Resolution Template
+
+```markdown
+## ✅ Completed
+
+The projects page now prominently displays Hacktoberfest 2025 hackathon winners with a new reusable component.
+
+## 🎯 What Was Implemented
+
+### New Component
+Created `WinnersCard` component with:
+- Customizable badge text and colors
+- Two size variants (large/medium)
+- Links to project detail pages
+- Responsive design with hover effects
+
+### Winners Section
+Displays at top of `/projects`:
+- 🏆 Best Overall Project - "Totoo Ba Ito?"
+- ⛓️ Best Use of Blockchain - "Barangay Konek"
+- 🤖 Best Use of AI - "Quiz Attack"
+- 🎉 Best Easter Egg - "BayanihanCebu"
+- 🌟 Best Open Source Contribution - (To Be Announced)
+
+### Key Features
+✅ Automatic winner discovery from submissions  
+✅ Fallback placeholders if winners not found  
+✅ No duplication in hackathon listing  
+✅ Cards link to `/projects/submitted/[id]`  
+✅ Responsive layout with distinct badge colors  
+✅ Reusable component for future use
+
+## 📋 Verification
+
+- ✅ Winners appear at top of `/projects`
+- ✅ No duplicates in "Hackathon Projects" section
+- ✅ Links navigate to project detail pages
+- ✅ Responsive on all screen sizes
+- ✅ TypeScript compiles without errors
+
+## 📚 Documentation
+
+Full documentation: `docs/HACKATHON_WINNERS.md`
+
+## 🔄 Next Steps
+
+- [ ] Update contribution winner when announced
+- [ ] Consider adding video/demo URLs to project details
+
+---
+
+Winners are now live on the projects page! 🎉
+```
+
+---
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+1. **Dynamic Configuration**: Store winner mappings in a config file or database
+2. **Admin UI**: Add admin interface to select winners from approved submissions
+3. **More Categories**: Add additional award categories as needed
+4. **Winner Badges**: Add special badges to winner profiles
+5. **Animation**: Add entrance animations for winner cards
+6. **Social Sharing**: Add "Share Winner" buttons for social media
+7. **Winner Spotlight**: Create dedicated `/winners` page with detailed information
+8. **Historical Winners**: Archive past years' winners
+
+---
+
+**Documentation Last Updated:** October 29, 2025


### PR DESCRIPTION
Summary
- Adds a Winners section to the Projects page that highlights Hacktoberfest 2025 winners.
- New reusable component: `app/components/winners-card.tsx`.
- Winners auto-discovered from approved submissions (title-matching); fallbacks used when missing.
- Winner cards link to project detail pages (`/projects/submitted/[id]`) instead of external GitHub.
- Contribution winner remains a "To Be Announced" placeholder.

Files changed
- app/components/winners-card.tsx (new)
- app/projects/page.tsx (winners section + exclusion from listing)
- docs/HACKATHON_WINNERS.md (documentation)

How to test
1. Checkout branch and run dev:
   pnpm install
   pnpm run dev
2. Visit http://localhost:3000/projects
3. Verify:
   - Winners appear at top with correct badges/colors
   - Clicking a winner opens `/projects/submitted/[id]`
   - Winners are not duplicated in the regular projects list
   - Contribution winner shows "To Be Announced" placeholder
   - Responsive layout and no console/type errors

Notes
- If a winner project isn't found among approved submissions, placeholder data is shown.
- Update the contribution winner once announced by replacing the placeholder in `app/projects/page.tsx`.

Closes #51