### PR TITLE
fix(projects): fixed Open for PRs

### DIFF
--- a/app/projects/submitted-project-card.tsx
+++ b/app/projects/submitted-project-card.tsx
@@ -14,7 +14,7 @@ export function SubmittedProjectCard({ project }: { project: SubmittedProject })
             <h3 className="text-xl font-bold text-zinc-100 group-hover:text-white">
               {project.title}
             </h3>
-            <span className="inline-flex items-center px-2 py-1 text-xs font-medium text-green-400 bg-green-900/50 border border-green-800 rounded-full">
+            <span className="flex-shrink-0 inline-flex items-center px-2 py-1 text-xs font-medium text-green-400 bg-green-900/50 border border-green-800 rounded-full">
               Open for PRs
             </span>
           </div>


### PR DESCRIPTION
📝 Summary
Fixes layout issue where the "Open for PRs" badge would shrink when project titles were long.

✨ Changes

✅ Added flex-shrink-0 class to the "Open for PRs" badge to maintain consistent width regardless of title length.

🧪 Testing Steps

Go to any project card with a long title.

Verify that the "Open for PRs" badge maintains its size and alignment.

Confirm layout remains consistent across screen sizes.

Closes #24