### PR TITLE
feat(feat(projects): add static video mapping for submitted projects)

### DIFF
--- a/app/projects/submitted/[id]/page.tsx
+++ b/app/projects/submitted/[id]/page.tsx
@@ -10,6 +10,45 @@ import { Metadata } from "next";
 
 const redis = Redis.fromEnv();
 
+// Static mapping of project titles to video URLs
+const PROJECT_VIDEO_MAPPING: { [key: string]: string } = {
+  "bayanihancebu": "https://youtu.be/riHq0HgD0iA",
+  "barangay konek": "https://youtu.be/qRyh4UJRBvI",
+  "the_adaptifork": "https://youtu.be/alLE0aPBeuc",
+  "sabot": "https://youtu.be/SOUhmg-Kqlo",
+  "finding dormy": "https://youtu.be/QJYk7eg1DGE",
+  "trustchain": "https://youtu.be/hPOnchVn22I",
+  "totoo ba ito": "https://youtu.be/CbO9pHo4uVQ",
+  "marshal": "https://youtu.be/Qo1ETgeX6QY",
+};
+
+// Helper function to get video URL for a project
+function getVideoUrlForProject(title: string): string | undefined {
+  const normalizedTitle = title.toLowerCase().trim();
+  
+  // Direct match first
+  if (PROJECT_VIDEO_MAPPING[normalizedTitle]) {
+    return PROJECT_VIDEO_MAPPING[normalizedTitle];
+  }
+  
+  // Check if title contains any of the mapped keys
+  for (const [key, url] of Object.entries(PROJECT_VIDEO_MAPPING)) {
+    if (normalizedTitle.includes(key) || key.includes(normalizedTitle)) {
+      return url;
+    }
+  }
+  
+  return undefined;
+}
+
+// Helper function to convert YouTube URL to embed format
+function getYouTubeEmbedUrl(url: string): string {
+  return url
+    .replace('youtu.be/', 'youtube.com/embed/')
+    .replace('watch?v=', 'embed/')
+    .replace('youtube.com/embed/embed/', 'youtube.com/embed/');
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -67,6 +106,9 @@ export default async function SubmittedProjectPage({
   if (!project) {
     notFound();
   }
+
+  // Get video URL from mapping or from project data
+  const videoUrl = project.videoUrl || getVideoUrlForProject(project.title);
 
   return (
     <div className="relative pb-16">
@@ -174,6 +216,24 @@ export default async function SubmittedProjectPage({
             </div>
           </div>
         </Card>
+
+        {/* Project Video */}
+        {videoUrl && (
+          <Card>
+            <div className="p-6 space-y-4">
+              <h2 className="text-xl font-semibold text-zinc-100">Project Demo Video</h2>
+              <div className="aspect-video w-full">
+                <iframe
+                  src={getYouTubeEmbedUrl(videoUrl)}
+                  title={`${project.title} Demo Video`}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  className="w-full h-full rounded-lg border-0"
+                />
+              </div>
+            </div>
+          </Card>
+        )}
 
         {/* Team Members */}
         {project.projectType === "hackathon" && project.teamMembers && project.teamMembers.length > 0 && (

--- a/app/projects/utils.ts
+++ b/app/projects/utils.ts
@@ -53,6 +53,7 @@ export interface SubmittedProject {
 	repository: string;
 	url?: string;
 	image?: string;
+	videoUrl?: string;
 	email: string;
 	submittedBy: string;
 	submittedAt: string;

--- a/docs/PROJECT_VIDEOS.md
+++ b/docs/PROJECT_VIDEOS.md
@@ -1,0 +1,84 @@
+# Video URLs for Hacktoberfest Projects
+
+## Overview
+
+Added static video URL mapping to display project demo videos on project detail pages.
+
+## Implementation
+
+### Static Mapping
+
+Videos are mapped by project title in `app/projects/submitted/[id]/page.tsx`:
+
+```typescript
+const PROJECT_VIDEO_MAPPING: { [key: string]: string } = {
+  "bayanihancebu": "https://youtu.be/riHq0HgD0iA",
+  "barangay konek": "https://youtu.be/qRyh4UJRBvI",
+  "the_adaptifork": "https://youtu.be/alLE0aPBeuc",
+  "sabot": "https://youtu.be/SOUhmg-Kqlo",
+  "finding dormy": "https://youtu.be/QJYk7eg1DGE",
+  "trustchain": "https://youtu.be/hPOnchVn22I",
+  "totoo ba ito": "https://youtu.be/CbO9pHo4uVQ",
+  "marshal": "https://youtu.be/Qo1ETgeX6QY",
+};
+```
+
+### How It Works
+
+1. When a project page loads, it checks:
+   - First: `project.videoUrl` from database (if exists)
+   - Second: Static mapping by project title
+
+2. The `getVideoUrlForProject()` function:
+   - Normalizes project title (lowercase, trim)
+   - Checks for exact match
+   - Checks for partial match (title contains key or key contains title)
+
+3. YouTube URLs are converted to embed format automatically
+
+### Display
+
+- Video appears below "Project Links" section
+- Uses responsive 16:9 aspect ratio container
+- Embedded with YouTube iframe
+- Only shows if video URL is found
+
+## Files Changed
+
+- ✅ `app/projects/utils.ts` - Added `videoUrl?: string` to interface
+- ✅ `app/projects/submitted/[id]/page.tsx` - Added mapping and display logic
+- ✅ `app/api/admin/update-video/route.ts` - API for future dynamic updates
+
+## Video Mapping
+
+| Project Title | Video URL |
+|--------------|-----------|
+| BayanihanCebu | https://youtu.be/riHq0HgD0iA |
+| Barangay Konek | https://youtu.be/qRyh4UJRBvI |
+| The_AdaptiFork | https://youtu.be/alLE0aPBeuc |
+| Sabot | https://youtu.be/SOUhmg-Kqlo |
+| Finding Dormy | https://youtu.be/QJYk7eg1DGE |
+| TrustChain | https://youtu.be/hPOnchVn22I |
+| Totoo Ba Ito? | https://youtu.be/CbO9pHo4uVQ |
+| Marshal | https://youtu.be/Qo1ETgeX6QY |
+
+## Adding New Videos
+
+To add more videos, edit the `PROJECT_VIDEO_MAPPING` object in:
+`app/projects/submitted/[id]/page.tsx`
+
+Example:
+```typescript
+const PROJECT_VIDEO_MAPPING: { [key: string]: string } = {
+  // ... existing mappings
+  "new project name": "https://youtu.be/VIDEO_ID",
+};
+```
+
+## Future Enhancement
+
+The API endpoint `/api/admin/update-video` is available for migrating to dynamic video storage in the database when needed.
+
+---
+
+**Branch:** `yankinyurii123/cmnty-35-add-videos-for-each-hacktoberfest-projects`


### PR DESCRIPTION
Summary
- Add static video URL mapping and display logic for submitted project pages.
- Fall back to `project.videoUrl` if present, otherwise use the static mapping.
- Convert YouTube URLs to embed format and show responsive 16:9 iframe under Project Links.

Files changed
- app/projects/submitted/[id]/page.tsx — add mapping & display logic
- app/projects/utils.ts — add `videoUrl?: string` to SubmittedProject interface
- docs/PROJECT_VIDEOS.md — mapping and usage documentation

Branch
- yankinyurii123/cmnty-35-add-videos-for-each-hacktoberfest-projects

How to test
1. pnpm install && pnpm run dev
2. Visit any submitted project page (e.g. /projects/submitted/[id])
3. Verify video appears for mapped projects:
   - BayanihanCebu, Barangay Konek, The_AdaptiFork, Sabot, Finding Dormy, TrustChain, Totoo Ba Ito?, Marshal
4. Confirm responsive 16:9 embed and no console errors

Notes
- Mapping is static for now; API/admin endpoint exists for future dynamic updates.
- Update `PROJECT_VIDEO_MAPPING` in `app/projects/submitted/[id]/page.tsx` to add/remove mappings.

Closes #53