### PR TITLE
feat(home): updated 2025 impact data

### DIFF
--- a/app/components/home-highlights.tsx
+++ b/app/components/home-highlights.tsx
@@ -128,19 +128,19 @@ export function HomeHighlights() {
                 </h4>
                 <ul className="space-y-2 text-zinc-400 text-sm">
                   <li className="flex items-center">
-                    <span className="text-green-500 mr-2">✓</span> 15+ open
+                    <span className="text-green-500 mr-2">✓</span> 13 open
                     source projects created
                   </li>
                   <li className="flex items-center">
-                    <span className="text-green-500 mr-2">✓</span> 20+ teams
+                    <span className="text-green-500 mr-2">✓</span> 13 teams
                     participated in the hackathon
                   </li>
                   <li className="flex items-center">
-                    <span className="text-green-500 mr-2">✓</span> 150+
+                    <span className="text-green-500 mr-2">✓</span> 50+
                     developers engaged
                   </li>
                   <li className="flex items-center">
-                    <span className="text-green-500 mr-2">✓</span> 15+ partner
+                    <span className="text-green-500 mr-2">✓</span> 14 partner
                     communities involved
                   </li>
                 </ul>


### PR DESCRIPTION
Summary
Updated Hacktoberfest Cebu 2025 impact data

Changes:
✓ 15+ open source projects created                      ->           13 open source projects created      
✓ 20+ teams participated in the hackathon           ->           13 teams participated in the hackathon
✓ 150+ developers engaged                                  ->           50+ developers engaged    
✓ 15+ partner communities involved                    ->            14 partner communities involved  

How to Test:

1. git checkout yankinyurii123/cmnty-41-lets-correct-or-remove-this-information
2. pnpm install && pnpm run dev
3. Visit the Home/Hacktoberfest 2025 Winners section.

Confirm that:
Hacktoberfest Cebu 2025 impact data is accurate based on the submissions and entries.

Branch:
yankinyurii123/cmnty-41-lets-correct-or-remove-this-information

Closes #65