### PR TITLE
feat(projects): changed winners layout

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -181,7 +181,7 @@ export default async function ProjectsPage() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-8 mx-auto lg:grid-cols-2">
+        <div className="grid grid-rows-1 gap-8 mx-auto lg:grid-rows-2">
           {/* Best Overall Project - Large Featured Card */}
           <WinnersCard
             winner={winners.BestOverall}
@@ -190,29 +190,31 @@ export default async function ProjectsPage() {
             size="large"
           />
 
-          {/* Best Use of Blockchain - Large Card */}
-          <WinnersCard
-            winner={winners.BestBlockchain}
-            badge="⛓️ Best Use of Blockchain"
-            badgeColor="bg-orange-900"
-            size="large"
-          />
+          <div className="grid grid-cols-1 gap-8 mx-auto lg:grid-cols-3">
+             {/* Best Use of Blockchain - Large Card */}
+            <WinnersCard
+              winner={winners.BestBlockchain}
+              badge="⛓️ Best Use of Blockchain"
+              badgeColor="bg-orange-900"
+              size="large"
+            />
 
-          {/* Best Use of AI - Medium Card */}
-          <WinnersCard
-            winner={winners.BestAI}
-            badge="🤖 Best Use of AI"
-            badgeColor="bg-blue-900"
-            size="medium"
-          />
+            {/* Best Use of AI - Medium Card */}
+            <WinnersCard
+              winner={winners.BestAI}
+              badge="🤖 Best Use of AI"
+              badgeColor="bg-blue-900"
+              size="medium"
+            />
 
-          {/* Best Easter Egg - Medium Card */}
-          <WinnersCard
-            winner={winners.BestEasterEgg}
-            badge="🎉 Best Easter Egg"
-            badgeColor="bg-purple-900"
-            size="medium"
-          />
+            {/* Best Easter Egg - Medium Card */}
+            <WinnersCard
+              winner={winners.BestEasterEgg}
+              badge="🎉 Best Easter Egg"
+              badgeColor="bg-purple-900"
+              size="medium"
+            />
+          </div>
         </div>
 
         


### PR DESCRIPTION
Summary
- Updated winners layout

Highlighted Best Overall Winner

Changes:

- Full width for Totoo Ba Ito
- Then the rest, 3 grid below it.

How to Test:
1. git checkout yankinyurii123/cmnty-49-change-the-layout-to-hihglight-best-overall-winner
2. pnpm install && pnpm run dev
3. Visit the Home/Projects


Confirm that:

- Best Overall Winner is highlighted

Branch:
yankinyurii123/cmnty-41-lets-correct-or-remove-this-information

Closes #73